### PR TITLE
Add ohai_time to default whitelist

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ node.default[:whitelist] = {
   "macaddress" => true,
   "platform" => true,
   "platform_version" => true,
+  "ohai_time" => true,
   "kernel" => {
     "machine" => true,
     "name" => true,


### PR DESCRIPTION
ohai_time is what "knife status" uses to report when nodes last did a successful chef run

without it whitelisted, nodes with this cookbook installed always show up red with "many hours ago" in knife status, even though they have in fact ran chef-client successfully recently.
