### PR TITLE
Fixed namespace issues forWhitelist Class

### DIFF
--- a/libraries/whitelist.rb
+++ b/libraries/whitelist.rb
@@ -61,10 +61,10 @@ class Chef
     def save
       Chef::Log.info("Whitelisting node attributes")
       whitelist = self[:whitelist].to_hash
-      self.default_attrs = Whitelist.filter(self.default_attrs, whitelist)
-      self.normal_attrs = Whitelist.filter(self.normal_attrs, whitelist)
-      self.override_attrs = Whitelist.filter(self.override_attrs, whitelist)
-      self.automatic_attrs = Whitelist.filter(self.automatic_attrs, whitelist)
+      self.default_attrs = ::Whitelist.filter(self.default_attrs, whitelist)
+      self.normal_attrs = ::Whitelist.filter(self.normal_attrs, whitelist)
+      self.override_attrs = ::Whitelist.filter(self.override_attrs, whitelist)
+      self.automatic_attrs = ::Whitelist.filter(self.automatic_attrs, whitelist)
       old_save
     end
   end


### PR DESCRIPTION
Fixed namespace issues for differentiating between Chef::Whitelist from chef 11.14.2 and the Whitelist class that this cookbook provides. This is a trivial fix. 

I know that chef 11.14.2 has whitelisting built in, but the mechanism for whitelisting attributes there is different than how it's done in this cookbook. I like that cookbooks are able to simply specify what attributes they'd like to whitelist, unlike with chef 11.14.2 where you have to provide it a configuration file of the attributes you want white listed . However, the reason that this cookbook doesn't work with chef 11.14.2 is because of the namespace issue. The library in the white list cookbook is called 'Whitelist' which is the same name given to it in chef 11.14.2; however because of that, when the whitelist library reopens the Chef::Node.save function, it only calls 'Whitelist' instead of '::Whitelist', which causes it to use the builtin Chef::Whitelist class. 
